### PR TITLE
Added ability to disallow to use multiple backpack1 and backpack2 at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
      ["type"] = "item",
      ["image"] = "backpack_girl.png",
      ["unique"] = true,
-     ["useable"] = true,
+     ["useable"] = false,
      ["shouldClose"] = true,
      ["combinable"] = nil,
      ["description"] = "Backpack"
@@ -55,7 +55,7 @@
      ["type"] = "item",
      ["image"] = "backpack_boy.png",
      ["unique"] = true,
-     ["useable"] = true,
+     ["useable"] = false,
      ["shouldClose"] = true,
      ["combinable"] = nil,
      ["description"] = "Backpack"

--- a/client/client_main.lua
+++ b/client/client_main.lua
@@ -239,7 +239,6 @@ end
 
 local function dosomething(current, p)
      local dif_ = difference(p, current)
-
      for _, item in ipairs(dif_) do
           if isItemBackpack(item.name) then
                local backpack = getBackpack(item.name)
@@ -307,11 +306,11 @@ function StartThread()
           while true do
                traker.p_state = shallowcopy(traker.c_state)
                local items = QBCore.Functions.GetPlayerData().items
-               for _, hotbar_slot in pairs(Config.Hotbar) do
-                    if items[hotbar_slot] then
-                         traker.c_state[hotbar_slot] = items[hotbar_slot]
+               for _, back_slot in pairs(Config.backpackslots) do
+                    if items[back_slot] then
+                         traker.c_state[back_slot] = items[back_slot]
                     else
-                         traker.c_state[hotbar_slot] = 'empty'
+                         traker.c_state[back_slot] = 'empty'
                     end
                end
                if isChanged(traker.c_state, traker.p_state) then

--- a/config.lua
+++ b/config.lua
@@ -83,6 +83,14 @@ Config.Hotbar = {
      1, 2, 3, 4, 5, 41
 }
 
+-- which slots that packe bagpack in back or hand
+Config.backpackslots = {
+     -- added all slots bcoz players keeps backpack in other slot to hide from body
+     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41
+}
+
+Config.disallowmultiple = true -- true/false. true = disallow players to carry multiple backpacks at a time in inventory. appltied on only backpac1 and backpack2
+
 Config.duration = {
      open = 1, --sec
      close = 1
@@ -92,35 +100,41 @@ Config.duration = {
 
 Config.items = {
      ['backpack1'] = {
-          slots = 5,
+          usable = false, -- true/false = false = not creation of usable item. if false then bag can only open using /backpack command. also change this in qb-core/shared/item.lua file
+          slots = 10,
           size = 100000,
+
           male = {
-               ["bag"] = { item = 85, texture = 12 }
+               ["bag"] = { item = 17, texture = 4 } -- change item and texture as per your clothing pack
           },
 
           female = {
-               ["bag"] = { item = 45, texture = 0 }
+               ["bag"] = { item = 10, texture = 6 } -- change item and texture as per your clothing pack
           }
-
 
      },
      ['backpack2'] = {
-          slots = 6,
+          usable = false, -- true/false = false = not creation of usable item. if false then bag can only open using /backpack command. also change this in qb-core/shared/item.lua file
+          slots = 10,
           size = 100000,
+
           male = {
-               ["bag"] = { item = 85, texture = 12 }
+               ["bag"] = { item = 17, texture = 4 } -- change item and texture as per your clothing pack
           },
+
           female = {
-               ["bag"] = { item = 45, texture = 0 }
+               ["bag"] = { item = 10, texture = 6 } -- change item and texture as per your clothing pack
           }
      },
      ['briefcase'] = {
-          slots = 3,
+          usable = true,
+          slots = 5,
           size = 10000,
           locked = 'password',
           prop = props.suitcase2
      },
      ['paramedicbag'] = {
+          usable = true,
           slots = 10,
           size = 50000,
           prop = props.paramedicbag

--- a/config.lua
+++ b/config.lua
@@ -105,11 +105,11 @@ Config.items = {
           size = 100000,
 
           male = {
-               ["bag"] = { item = 17, texture = 4 } -- change item and texture as per your clothing pack
+               ["bag"] = { item = 85, texture = 12 } -- change item and texture as per your clothing pack
           },
 
           female = {
-               ["bag"] = { item = 10, texture = 6 } -- change item and texture as per your clothing pack
+               ["bag"] = { item = 45, texture = 0 } -- change item and texture as per your clothing pack
           }
 
      },
@@ -119,11 +119,11 @@ Config.items = {
           size = 100000,
 
           male = {
-               ["bag"] = { item = 17, texture = 4 } -- change item and texture as per your clothing pack
+               ["bag"] = { item = 85, texture = 12 } -- change item and texture as per your clothing pack
           },
 
           female = {
-               ["bag"] = { item = 10, texture = 6 } -- change item and texture as per your clothing pack
+               ["bag"] = { item = 45, texture = 0 } -- change item and texture as per your clothing pack
           }
      },
      ['briefcase'] = {


### PR DESCRIPTION
Added ability to disallow to use multiple backpack1 and backpack2 at a time
Player carrying 5 to 10+ backpack at a time in inventory with previous code. in this update this is fixed. if you have any other better solution then please add this to carry only 1 backpack at a time in inventory