### PR TITLE
Improvement #8 configurable backpack whitelist/blacklist + global blacklist items

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -53,6 +53,19 @@ local animations = {
                z_rotation = 75.0,
           }
      },
+     fishicebox = {
+          dict = 'missheistdocksprep1hold_cellphone',
+          anim = 'static',
+          bone = 'RightHand',
+          attaching_position = {
+               x = 0.5,
+               y = 0.0,
+               z = 0.0,
+               x_rotation = 0.0,
+               y_rotation = 270.0,
+               z_rotation = 0.0,
+          }
+     },
 }
 
 local props = {
@@ -75,7 +88,11 @@ local props = {
      paramedicbag = {
           model = 'xm_prop_smug_crate_s_medical',
           animation = animations.paramedicbag
-     }
+     },
+     fishicebox = {
+          model = 'prop_coolbox_01',
+          animation = animations.fishicebox
+     },
 }
 
 -- which slots are your hot bar
@@ -92,26 +109,18 @@ Config.duration = {
 
 Config.items = {
      ['backpack1'] = {
-          slots = 5,
-          size = 100000,
-          male = {
-               ["bag"] = { item = 85, texture = 12 }
-          },
-
-          female = {
-               ["bag"] = { item = 45, texture = 0 }
-          }
-
-
-     },
-     ['backpack2'] = {
           slots = 10,
           size = 100000,
+          prop = props.backpack2
+     },
+     ['backpack2'] = {
+          slots = 20,
+          size = 200000,
           male = {
                ["bag"] = { item = 85, texture = 12 }
           },
           female = {
-               ["bag"] = { item = 45, texture = 0 }
+               ["bag"] = { item = 85, texture = 13 }
           }
      },
      ['briefcase'] = {
@@ -124,6 +133,11 @@ Config.items = {
           slots = 10,
           size = 50000,
           prop = props.paramedicbag
+     },
+     ['fishicebox'] = {
+          slots = 40,
+          size = 200000,
+          prop = props.fishicebox
      },
 }
 
@@ -144,6 +158,19 @@ Config.Whitelist_items = {
           ['ifaks'] = true,
           ['painkillers'] = true,
           ['walkstick'] = true,
+     },
+     fishicebox = {
+          ['stingray'] = true,
+          ['flounder'] = true,
+          ['codfish'] = true,
+          ['mackerel'] = true,
+          ['bass'] = true,
+          ['fishingtin'] = true,
+          ['fishingboot'] = true,
+          ['killerwhale'] = true,
+          ['dolphin'] = true,
+          ['sharkhammer'] = true,
+          ['sharktiger'] = true,
      },
 }
 

--- a/config.lua
+++ b/config.lua
@@ -131,7 +131,20 @@ Config.Blacklist_items = {
      active = true,
      list = {
           'weapon_rpg'
+     },
+     backpack2 = {
+          ['lockpick'] = true
      }
+}
+
+Config.Whitelist_items = {
+     paramedicbag = {
+          ['firstaid'] = true,
+          ['bandage'] = true,
+          ['ifaks'] = true,
+          ['painkillers'] = true,
+          ['walkstick'] = true,
+     },
 }
 
 Config.whitelist = {

--- a/config.lua
+++ b/config.lua
@@ -105,7 +105,7 @@ Config.items = {
 
      },
      ['backpack2'] = {
-          slots = 6,
+          slots = 10,
           size = 100000,
           male = {
                ["bag"] = { item = 85, texture = 12 }
@@ -115,7 +115,7 @@ Config.items = {
           }
      },
      ['briefcase'] = {
-          slots = 3,
+          slots = 5,
           size = 10000,
           locked = 'password',
           prop = props.suitcase2
@@ -132,9 +132,9 @@ Config.Blacklist_items = {
      list = {
           'weapon_rpg'
      },
-     backpack2 = {
-          ['lockpick'] = true
-     }
+     -- backpack2 = {
+     --      ['lockpick'] = true
+     -- }
 }
 
 Config.Whitelist_items = {


### PR DESCRIPTION
Improvement #8
Now in config we can add whitelisted and blacklisted items depending on backpack type

```lua
Config.Blacklist_items = {
     active = true,
     list = {
          'weapon_rpg', -- existing global blacklist
     },
     backpack2 = { -- new configurable blacklist depending on backpack
          ['lockpick'] = true
     }
}

Config.Whitelist_items = {
     paramedicbag = { -- new configurable whitelist depending on backpack
          ['firstaid'] = true,
          ['bandage'] = true,
          ['ifaks'] = true,
          ['painkillers'] = true,
          ['walkstick'] = true,
     },
}
```